### PR TITLE
Logging: Don't create multiple handlers of the same type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.DS_Store
 /.idea/
 !example.env
+
+**/tests/**/out/

--- a/rembrain_robot_framework/logger/utils.py
+++ b/rembrain_robot_framework/logger/utils.py
@@ -66,4 +66,10 @@ def set_logger(project_description: dict, in_cluster: bool = True) -> None:
 
         logging.getLogger("pika").setLevel(logging.WARNING)
 
-    logging.root.addHandler(get_log_handler(project_description, in_cluster))
+    handler = get_log_handler(project_description, in_cluster)
+    # Don't add handlers of the type that have already been added
+    has_this_handler = main_logger.hasHandlers() and any(
+        (isinstance(handler, type(x)) for x in main_logger.handlers)
+    )
+    if not has_this_handler:
+        main_logger.addHandler(handler)

--- a/rembrain_robot_framework/tests/logging/cfg/config_test_crashing_doesnt_create_another_logger.yaml
+++ b/rembrain_robot_framework/tests/logging/cfg/config_test_crashing_doesnt_create_another_logger.yaml
@@ -1,0 +1,7 @@
+processes:
+  failing_process:
+    fail_threshold: 4
+    sleep_interval: 0.1
+
+shared_objects:
+  ok: Value:int

--- a/rembrain_robot_framework/tests/logging/tests.py
+++ b/rembrain_robot_framework/tests/logging/tests.py
@@ -1,0 +1,66 @@
+import glob
+import logging
+import time
+import os
+import unittest
+from contextlib import redirect_stderr
+import re
+
+from rembrain_robot_framework import RobotDispatcher
+from rembrain_robot_framework.tests.util import load_config, generate_process_dict
+from rembrain_robot_framework.tests.util.processes import FailingProcess
+
+process_map = {
+    "failing_process": FailingProcess
+}
+
+
+class TestLogging(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Check that an out dir exists
+        cls.out_dir_path = os.path.join(os.path.dirname(__file__), "out")
+        if not os.path.exists(cls.out_dir_path):
+            os.makedirs(cls.out_dir_path)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        files = glob.glob(f"{cls.out_dir_path}/*")
+        for f in files:
+            os.remove(f)
+
+    def test_crashing_doesnt_create_another_logger(self) -> None:
+        """
+        Testing that there are no duplicate loggers by creating a count-up-then-fail process
+        Keeping it running for a couple failures
+        Test passes if there are no count repeats in the end log result
+        """
+        cfg = load_config(self, self.test_crashing_doesnt_create_another_logger.__name__)
+        processes = generate_process_dict(cfg, process_map)
+        output_file = os.path.join(self.out_dir_path, f"{self.test_crashing_doesnt_create_another_logger.__name__}_output.txt")
+
+        # Assuming we're redirecting to stderr, if things change - gotta change here
+        # for some reason, redirecting to io.StringIO redirects only one line
+        # probably some multiprocessing issue.
+        # For now working around it by writing out to an output file and then reading it
+        with redirect_stderr(open(output_file, "w")):
+            dispatcher = RobotDispatcher(cfg, processes, in_cluster=False)
+            dispatcher.start_processes()
+            time.sleep(15)
+
+        with open(output_file, "r") as f:
+            log_data = f.read()
+            logged_counts = ""
+            count_regex = r"Count: (\d)"
+            for line in log_data.splitlines():
+                m = re.search(count_regex, line)
+                if m is not None:
+                    logged_counts += f"{m.group(1)}, "
+
+        self.assertNotIn("0, 0", logged_counts)
+        self.assertIn("0, 1, 2, 3", logged_counts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rembrain_robot_framework/tests/tests.py
+++ b/rembrain_robot_framework/tests/tests.py
@@ -15,7 +15,7 @@ class P1(RobotProcess):
     def run(self) -> None:
         self.publish("hi")
 
-        logging.info(self.name + " hi sended")
+        logging.info(self.name + " hi sent")
 
 
 class P2(RobotProcess):
@@ -30,7 +30,7 @@ class P2(RobotProcess):
             record: str = self.consume()
             if record == self.to_expect:
                 self.shared.hi_received.value += 1
-                logging.info(f"{self.name}  {record}  received")
+                logging.info(f"{self.name} {record} received")
 
 
 class P3(RobotProcess):
@@ -50,7 +50,7 @@ class P4(RobotProcess):
     def run(self) -> None:
         self.publish(queue_name="messages1", message="hi1")
         self.publish(queue_name="messages2", message="hi2")
-        logging.info(self.name + " hi sended")
+        logging.info(self.name + " hi sent")
 
 
 class AP1(RobotProcess):

--- a/rembrain_robot_framework/tests/util/__init__.py
+++ b/rembrain_robot_framework/tests/util/__init__.py
@@ -1,0 +1,1 @@
+from rembrain_robot_framework.tests.util.config_loader import *

--- a/rembrain_robot_framework/tests/util/config_loader.py
+++ b/rembrain_robot_framework/tests/util/config_loader.py
@@ -1,0 +1,19 @@
+import os
+import inspect
+import yaml
+
+
+def load_config(test_obj, test_func, cfg_dir="cfg") -> dict:
+    """
+    Loads and returns config from the path
+    `./cfg/config_{test_func}.yaml`
+    relative to the test_class file
+    """
+    class_dir = os.path.dirname(inspect.getfile(test_obj.__class__))
+    cfg_path = os.path.join(class_dir, cfg_dir, f"config_{test_func}.yaml")
+    with open(cfg_path) as f:
+        return yaml.load(f, Loader=yaml.BaseLoader)
+
+
+def generate_process_dict(cfg: dict, process_map: dict) -> dict:
+    return {p: {"process_class": process_map[p]} for p in cfg["processes"]}

--- a/rembrain_robot_framework/tests/util/processes/FailingProcess.py
+++ b/rembrain_robot_framework/tests/util/processes/FailingProcess.py
@@ -1,0 +1,26 @@
+import logging
+import time
+
+from rembrain_robot_framework import RobotProcess
+
+
+class FailingProcess(RobotProcess):
+    """
+    Process that fails after :fail_threshold loops
+    waits for :sleep_interval inbetween
+    """
+    def __init__(self, *args, **kwargs):
+        logging.debug(f"{self.__class__} constructor")
+        super(FailingProcess, self).__init__(*args, **kwargs)
+        self.fail_threshold = int(kwargs.get("fail_threshold", 3))
+        self.sleep_interval = float(kwargs.get("sleep_interval", 0.5))
+        self.count = 0
+
+    def run(self) -> None:
+        self.count = 0
+        while True:
+            logging.info(f"Count: {self.count}")
+            self.count += 1
+            if self.count >= self.fail_threshold:
+                raise RuntimeError("Reached failure threshold")
+            time.sleep(self.sleep_interval)

--- a/rembrain_robot_framework/tests/util/processes/__init__.py
+++ b/rembrain_robot_framework/tests/util/processes/__init__.py
@@ -1,0 +1,1 @@
+from rembrain_robot_framework.tests.util.processes.FailingProcess import FailingProcess

--- a/rembrain_robot_framework/utils.py
+++ b/rembrain_robot_framework/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 import time
 import typing as T
@@ -6,6 +7,11 @@ from functools import wraps
 from multiprocessing import Value, Lock, Manager
 
 from rembrain_robot_framework.logger import set_logger
+
+# This is all so we can import RobotProcess for typechecking without circular imports
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from rembrain_robot_framework.process import RobotProcess
 
 
 def generate(name: str, manager: Manager) -> T.Any:
@@ -57,7 +63,7 @@ def keep_alive(start_process_func: T.Callable) -> T.Callable:
 
 
 @keep_alive
-def start_process(process_class: T.Any, *args, **kwargs) -> None:
+def start_process(process_class: RobotProcess, *args, **kwargs) -> None:
     process: T.Any = None
     set_logger(kwargs["project_description"], kwargs.get("in_cluster", True))
 


### PR DESCRIPTION
This can happen on process restart

Additionally:
 - fixed some typos in existing tests
 - added type hints in utils.start_process function