### PR TITLE
Added keepalive ping to WsRobotProcess

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,5 +1,4 @@
 amqp==5.0.6
-numpy==1.21.2
 opencv-python==4.4.0.46
 pika==1.2.0
 python-json-logger==2.0.2


### PR DESCRIPTION
Should help with dropping websocket connections.
Also the dependent processes should no longer be trying to send ping wscommands

Additionally removed numpy from requirements.txt, since it's already required by opencv-contrib, and pinning a single numpy version breaks builds on Python 3.6 (numpy 1.21 requires Python >= 3.7)